### PR TITLE
Add CocoaPods installation step to iOS workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,6 +14,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install CocoaPods
+        run: |
+            pod install
+
+        
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")


### PR DESCRIPTION
Added a step to install CocoaPods before setting the default scheme.